### PR TITLE
Handle oversize SelfReport payload

### DIFF
--- a/src/EQWNow.h
+++ b/src/EQWNow.h
@@ -12,6 +12,7 @@
 #include <freertos/queue.h>
 
 const size_t EQW_MAX_NAME_LEN = 32;
+const size_t EQW_MAX_PAYLOAD_LEN = 243; // max bytes allowed for payload in send()
 
 struct EQWDeviceInfo {
     uint8_t deviceByteA = 0;


### PR DESCRIPTION
## Summary
- add EQW_MAX_PAYLOAD_LEN constant
- truncate SelfReport fields if payload would exceed the limit

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_b_6863ce1bb6208324bced9478c6d0d0ff