### PR TITLE
Add pending reply timeout cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,6 @@ register handlers by name or `on(0x01, handler)` for direct IDs. Besides
 `send()` for fire-and-forget messages, `request()` allows sending a packet and
 supplying a callback to handle the reply when it arrives. All incoming packets
 are queued internally and processed in `EQWNow::process()` so callbacks execute
-from your main loop rather than the Wi‑Fi driver task.
+from your main loop rather than the Wi‑Fi driver task. Pending reply handlers
+expire after a timeout (10&nbsp;seconds by default) which can be changed via
+`setPendingReplyTimeout()`.

--- a/src/EQWNow.h
+++ b/src/EQWNow.h
@@ -52,6 +52,8 @@ public:
                      size_t len,
                      ReceiveCallback replyCb);
 
+    void setPendingReplyTimeout(uint32_t timeoutMs) { pendingReplyTimeoutMs = timeoutMs; }
+
     void process();
 
 private:
@@ -68,7 +70,12 @@ private:
     static EQWNow* instance;
 
     std::map<uint8_t, ReceiveCallback> callbacks;
-    std::map<uint16_t, ReceiveCallback> pendingReplies;
+    struct PendingReply {
+        ReceiveCallback cb;
+        uint32_t timestamp;
+    };
+    std::map<uint16_t, PendingReply> pendingReplies;
+    uint32_t pendingReplyTimeoutMs = 10000;
     uint16_t nextRequestId = 1;
 
     std::set<uint8_t> registeredCommands;


### PR DESCRIPTION
## Summary
- track timestamp for each pending reply
- automatically clear old replies during `process()`
- document reply timeout configuration in README

## Testing
- `platformio run -d examples/basic`

------
https://chatgpt.com/codex/tasks/task_b_6863ce20b6908324b4f4f9d4ff9be821