### PR TITLE
Add user command definition

### DIFF
--- a/src/EQWCommands.cpp
+++ b/src/EQWCommands.cpp
@@ -1,0 +1,36 @@
+#include "EQWCommands.h"
+#include <map>
+#include <string>
+
+// Maps for user-defined commands
+static std::map<std::string, uint8_t> userNameToId;
+static std::map<uint8_t, std::string> userIdToName;
+static uint8_t nextUserId = 0xEB;
+
+uint8_t eqwCommandIdForName(const std::string& name) {
+    for (const auto& entry : kEQWCommandTable) {
+        if (name == entry.name) return entry.id;
+    }
+    auto it = userNameToId.find(name);
+    if (it != userNameToId.end()) return it->second;
+    return 0xFF;
+}
+
+const char* eqwCommandNameForId(uint8_t id) {
+    for (const auto& entry : kEQWCommandTable) {
+        if (id == entry.id) return entry.name;
+    }
+    auto it = userIdToName.find(id);
+    if (it != userIdToName.end()) return it->second.c_str();
+    return nullptr;
+}
+
+uint8_t defineUserCommand(const std::string& name) {
+    uint8_t existing = eqwCommandIdForName(name);
+    if (existing != 0xFF) return existing;
+    if (nextUserId > 0xFD) return 0xFF; // Out of reserved IDs
+    uint8_t id = nextUserId++;
+    userNameToId[name] = id;
+    userIdToName[id] = name;
+    return id;
+}

--- a/src/EQWCommands.h
+++ b/src/EQWCommands.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <string>
-#include <map>
 
 struct EQWCommandEntry {
     const char* name;
@@ -34,20 +33,11 @@ static const EQWCommandEntry kEQWCommandTable[] = {
     {"SDSpace", 0x91},
     {"FileList", 0x92},
     {"Macro", 0xC8},
+
 };
 
-inline uint8_t eqwCommandIdForName(const std::string& name) {
-    for (const auto& entry : kEQWCommandTable) {
-        if (name == entry.name) return entry.id;
-    }
-    return 0xFF;
-}
-
-inline const char* eqwCommandNameForId(uint8_t id) {
-    for (const auto& entry : kEQWCommandTable) {
-        if (id == entry.id) return entry.name;
-    }
-    return nullptr;
-}
+uint8_t eqwCommandIdForName(const std::string& name);
+const char* eqwCommandNameForId(uint8_t id);
+uint8_t defineUserCommand(const std::string& name);
 
 #endif // EQW_COMMANDS_H


### PR DESCRIPTION
## Summary
- add runtime user command registration
- allow lookup functions to check user-defined commands

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_b_6863ce2a76d88324a1a9926c2c668527